### PR TITLE
Fix typo in code sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ end
 You can use this gem to add Sidekiq client middleware that will either warn you or raise an error when workers are scheduled inside of a database transaction. You can do this by simply adding this to your application's initialization code:
 
 ```ruby
-require 'sidekiq/transaction-guard'
+require 'sidekiq/transaction_guard'
 
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|


### PR DESCRIPTION
The gem name uses underscore and the sample used dash, which resulted in load error.