### PR TITLE
Fix database_cleaner require

### DIFF
--- a/lib/sidekiq/transaction_guard/database_cleaner.rb
+++ b/lib/sidekiq/transaction_guard/database_cleaner.rb
@@ -1,5 +1,5 @@
 require 'sidekiq/transaction_guard'
-require 'database_cleaner'
+require 'database_cleaner/active_record'
 require 'database_cleaner/active_record/transaction'
 
 module Sidekiq


### PR DESCRIPTION
Fix `database_cleaner` require to work on Rails 5 and above